### PR TITLE
Parse: allow trailing commas in array (not just object)

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -60,7 +60,6 @@ func TestParser(t *testing.T) {
 
 		// array with errors
 		"[,]":           {want: "[]", errors: true},
-		"[ 1, 5, ]":     {want: "[1,5]"},
 		"[ 1, 2, ]":     {options: &ParseOptions{TrailingCommas: false}, want: "[1,2]", errors: true},
 		"[ 1 2, 3]":     {want: "[1,2,3]", errors: true},
 		"[ ,1, 2, 3 ]":  {want: "[1,2,3]", errors: true},
@@ -76,8 +75,10 @@ func TestParser(t *testing.T) {
 		`{ "hello": [] }`:                {want: `{"hello":[]}`},
 		`{ "hello": [], "world": {}, }`:  {want: `{"hello":[],"world":{}}`},
 		`{ "hello2": [], "world": {} }`:  {want: `{"hello2":[],"world":{}}`},
+		"[ 1, 5, ]":                      {want: "[1,5]"},
 		`{ "hello2": [], }`:              {options: &ParseOptions{TrailingCommas: false}, want: `{"hello2":[]}`, errors: true},
 		`{ "hello2": [], "world": {}, }`: {options: &ParseOptions{TrailingCommas: false}, want: `{"hello2":[],"world":{}}`, errors: true},
+		"[ 1, 6, ]":                      {options: &ParseOptions{TrailingCommas: false}, want: "[1,6]", errors: true},
 	}
 	for input, test := range tests {
 		label := fmt.Sprintf("%q", input)
@@ -92,6 +93,9 @@ func TestParser(t *testing.T) {
 		output, errors := Parse(input, *options)
 		if test.errors && errors == nil {
 			t.Errorf("%s: got no parse errors, want parse errors", label)
+		}
+		if !test.errors && errors != nil {
+			t.Errorf("%s: got parse errors %v, want no parse errors", label, errors)
 		}
 		if string(output) != test.want {
 			t.Errorf("%s: got output %s, want %s", label, output, test.want)

--- a/visitor.go
+++ b/visitor.go
@@ -260,6 +260,9 @@ func (w *walker) parseArray() bool {
 			}
 			w.onSeparator(',')
 			w.scanNext() // consume comma
+			if w.scanner.Token() == CloseBracketToken && w.options.TrailingCommas {
+				break
+			}
 		} else if needsComma {
 			w.handleError(CommaExpected, nil, nil)
 		}


### PR DESCRIPTION
Related PR to the TypeScript version of this lib: https://github.com/Microsoft/node-jsonc-parser/pull/6