### PR TITLE
Treat the empty string as invalid

### DIFF
--- a/json_stringer.go
+++ b/json_stringer.go
@@ -4,9 +4,9 @@ package jsonx
 
 import "strconv"
 
-const _ParseErrorCode_name = "InvalidSymbolInvalidNumberFormatPropertyNameExpectedValueExpectedColonExpectedCommaExpectedCloseBraceExpectedCloseBracketExpectedEndOfFileExpected"
+const _ParseErrorCode_name = "InvalidSymbolInvalidNumberFormatPropertyNameExpectedValueExpectedColonExpectedCommaExpectedCloseBraceExpectedCloseBracketExpectedEndOfFileExpectedEmptyStringIsInvalid"
 
-var _ParseErrorCode_index = [...]uint8{0, 13, 32, 52, 65, 78, 91, 109, 129, 146}
+var _ParseErrorCode_index = [...]uint8{0, 13, 32, 52, 65, 78, 91, 109, 129, 146, 166}
 
 func (i ParseErrorCode) String() string {
 	if i < 0 || i >= ParseErrorCode(len(_ParseErrorCode_index)-1) {

--- a/parser.go
+++ b/parser.go
@@ -27,6 +27,10 @@ type ParseOptions struct {
 //
 // Source: https://github.com/Microsoft/vscode/blob/c0bc1ace7ca3ce2d6b1aeb2bde9d1bb0f4b4bae6/src/vs/base/common/json.ts#L638
 func Parse(text string, options ParseOptions) ([]byte, []ParseErrorCode) {
+	if text == "" {
+		return nil, []ParseErrorCode{EmptyStringIsInvalid}
+	}
+
 	var currentProperty struct {
 		name  string
 		valid bool
@@ -114,4 +118,5 @@ const (
 	CloseBraceExpected
 	CloseBracketExpected
 	EndOfFileExpected
+	EmptyStringIsInvalid
 )

--- a/parser_test.go
+++ b/parser_test.go
@@ -35,14 +35,14 @@ func TestParser(t *testing.T) {
 		"1.2E-3 // comment":         {want: "1.2E-3"},
 
 		// objects
-		"{}":                                                                                                        {want: "{}"},
-		`{ "foo": true }`:                                                                                           {want: `{"foo":true}`},
-		`{ "bar": 8, "xoo": "foo" }`:                                                                                {want: `{"bar":8,"xoo":"foo"}`},
-		`{ "hello": [], "world": {} }`:                                                                              {want: `{"hello":[],"world":{}}`},
-		`{ "a": false, "b": true, "c": [ 7.4 ] }`:                                                                   {want: `{"a":false,"b":true,"c":[7.4]}`},
+		"{}":                           {want: "{}"},
+		`{ "foo": true }`:              {want: `{"foo":true}`},
+		`{ "bar": 8, "xoo": "foo" }`:   {want: `{"bar":8,"xoo":"foo"}`},
+		`{ "hello": [], "world": {} }`: {want: `{"hello":[],"world":{}}`},
+		`{ "a": false, "b": true, "c": [ 7.4 ] }`: {want: `{"a":false,"b":true,"c":[7.4]}`},
 		`{ "blockComment": ["/*", "*/"], "brackets": [ ["{", "}"], ["[", "]"], ["(", ")"] ], "lineComment": "//" }`: {want: `{"blockComment":["/*","*/"],"brackets":[["{","}"],["[","]"],["(",")"]],"lineComment":"//"}`},
 		`{ "hello": { "again": { "inside": 5 }, "world": 1 }}`:                                                      {want: `{"hello":{"again":{"inside":5},"world":1}}`},
-		`{ "foo": /*hello*/true }`:                                                                                  {want: `{"foo":true}`},
+		`{ "foo": /*hello*/true }`: {want: `{"foo":true}`},
 
 		// arrays
 		"[]":                {want: "[]"},

--- a/parser_test.go
+++ b/parser_test.go
@@ -17,7 +17,7 @@ func TestParser(t *testing.T) {
 		want    string
 		errors  bool
 	}{
-		"": {want: ""},
+		"": {want: "", errors: true},
 
 		// literals
 		"true":                      {want: "true"},


### PR DESCRIPTION
The empty string is neither valid JSONC, nor JSON5 https://json5.org/

Not returning an error when given the empty string has caused a few bugs:

- https://github.com/sourcegraph/sourcegraph/issues/1784
- https://github.com/sourcegraph/sourcegraph/issues/1645

Another way to fix those bugs is to treat the empty string as `{}`, but the choice of `{}` might not be correct for other consumers of this library (e.g. why not `null`? There doesn't seem to be an obvious canonical default.).